### PR TITLE
Fix the `Name` annotation not being used when using `toJson` with tables

### DIFF
--- a/ballerina/tests/to_json_test.bal
+++ b/ballerina/tests/to_json_test.bal
@@ -81,6 +81,26 @@ function testToJsonWithXML() {
     test:assertEquals(j, x1.toString());
 }
 
+type Employee record {|
+    readonly int id;
+    string name;
+    string dept;
+|};
+
+@test:Config
+function testToJsonWithTables() {
+    table<Employee> key (id) tb = table [
+        {id: 1001, name: "Mary", dept: "legal"},
+        {id: 1002, name: "John", dept: "finance"}
+    ];
+    json tbJson = toJson(tb);
+    test:assertTrue(tbJson is json[]);
+    test:assertEquals(tbJson, <json> [
+        {id: 1001, name: "Mary", dept: "legal"},
+        {id: 1002, name: "John", dept: "finance"}
+    ]);
+}
+
 type TestRecord3 record {|
     @Name {
         value: "a-o"
@@ -116,7 +136,7 @@ type NestedRecord3 record {
 };
 
 @test:Config
-function testToJsonWithNameANnotation() {
+function testToJsonWithNameAnnotation() {
     TestRecord3 r = {
         a: "name",
         b: "b name",
@@ -172,6 +192,18 @@ function testToJsonWithNameANnotation() {
     json|Error j2 = toJson(n);
     test:assertTrue(j2 is json);
     test:assertEquals(j2, out2);
+
+    table<TestRecord3> tb = table [
+        {a: "a value", b: "b value", c: 1001},
+        {a: "a value 2", b: "b value 2", c: 1002}
+    ];
+    json j3 = toJson(tb);
+    test:assertTrue(j3 is json[]);
+    json[] out3 = [
+        {"a-o": "a value", "b-o": "b value", c: 1001},
+        {"a-o": "a value 2", "b-o": "b value 2", c: 1002}
+    ];
+    test:assertEquals(j3, out3);
 }
 
 type TestRecord4 record {|
@@ -214,6 +246,17 @@ function testToJsonWithCyclicValues() {
     test:assertTrue(r3 is error);
     error r3Err = <error> r3;
     test:assertEquals("the value has a cyclic reference", r3Err.message());
+
+    table<record {readonly int id; string name; record {} details;}> key (id) v4 =
+        table [
+            {id: 1023, name: "Joy", details: {}}
+        ];
+    record {} details = v4.get(1023).details;
+    details["tb"] = v4;
+    json|error r4 = trap toJsonWithCyclicValues(v4);
+    test:assertTrue(r4 is error);
+    error r4Err = <error> r4;
+    test:assertEquals("the value has a cyclic reference", r4Err.message());
 }
 
 function toJsonWithCyclicValues(anydata val) returns json {

--- a/native/src/main/java/io/ballerina/lib/data/jsondata/json/Native.java
+++ b/native/src/main/java/io/ballerina/lib/data/jsondata/json/Native.java
@@ -37,6 +37,7 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BStream;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTable;
 import io.ballerina.runtime.api.values.BTypedesc;
 
 import java.io.ByteArrayInputStream;
@@ -119,6 +120,17 @@ public class Native {
             }
 
             return jsonObject;
+        }
+
+        if (value instanceof BTable tableValue) {
+            int length = tableValue.size();
+            Object[] convertedValues = new Object[length];
+
+            int index = 0;
+            for (Object tableMember : tableValue.values()) {
+                convertedValues[index++] = toJson(tableMember, visitedValues);
+            }
+            return ValueCreator.createArrayValue(convertedValues, PredefinedTypes.TYPE_JSON_ARRAY);
         }
 
         return JsonUtils.convertToJson(value);


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7348

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
