### PR TITLE
Fix toJson failing with repeated structured members at the same level

### DIFF
--- a/native/src/main/java/io/ballerina/lib/data/jsondata/json/Native.java
+++ b/native/src/main/java/io/ballerina/lib/data/jsondata/json/Native.java
@@ -109,7 +109,9 @@ public class Native {
             int length = (int) listValue.getLength();
             Object[] convertedValues = new Object[length];
             for (int i = 0; i < length; i++) {
-                convertedValues[i] = toJson(listValue.get(i), visitedValues);
+                Object memValue = listValue.get(i);
+                convertedValues[i] = toJson(memValue, visitedValues);
+                visitedValues.remove(memValue);
             }
             return ValueCreator.createArrayValue(convertedValues, PredefinedTypes.TYPE_JSON_ARRAY);
         }
@@ -122,6 +124,7 @@ public class Native {
             for (BString entryKey : mapValue.getKeys()) {
                 Object entryValue = mapValue.get(entryKey);
                 jsonObject.put(getNameAnnotation(mapValue, entryKey), toJson(entryValue, visitedValues));
+                visitedValues.remove(entryValue);
             }
 
             return jsonObject;
@@ -134,6 +137,7 @@ public class Native {
             int index = 0;
             for (Object tableMember : tableValue.values()) {
                 convertedValues[index++] = toJson(tableMember, visitedValues);
+                visitedValues.remove(tableMember);
             }
             return ValueCreator.createArrayValue(convertedValues, PredefinedTypes.TYPE_JSON_ARRAY);
         }


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7363

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
