### PR TITLE
Fix union type conversion issue in `parseAsType` API in OpenAI responses

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 authors = ["Ballerina"]
 keywords = ["json", "json path", "json-transform", "json transform", "json to json", "json-convert", "json convert"]
 repository = "https://github.com/ballerina-platform/module-ballerina-data.jsondata"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "jsondata-native"
-version = "1.1.3"
-path = "../native/build/libs/data.jsondata-native-1.1.3.jar"
+version = "1.1.4"
+path = "../native/build/libs/data.jsondata-native-1.1.4-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 path = "./lib/json-path-2.9.0.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "constraint-compiler-plugin"
 class = "io.ballerina.lib.data.jsondata.compiler.JsondataCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/data.jsondata-compiler-plugin-1.1.3.jar"
+path = "../compiler-plugin/build/libs/data.jsondata-compiler-plugin-1.1.4-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "file"},
@@ -153,7 +153,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.10.0"
+version = "1.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/native/src/main/java/io/ballerina/lib/data/jsondata/json/JsonTraverse.java
+++ b/native/src/main/java/io/ballerina/lib/data/jsondata/json/JsonTraverse.java
@@ -168,10 +168,22 @@ public class JsonTraverse {
                     }
 
                     for (Type memberType : unionType.getMemberTypes()) {
+                        int fieldHierarchySize = fieldHierarchy.size();
+                        int restTypeSize = restType.size();
+                        int fieldNamesSize = fieldNames.size();
                         try {
                             return traverseJson(json, memberType);
                         } catch (Exception e) {
-                            // Ignore
+                            // Restore stack state after failed union member attempt
+                            while (fieldHierarchy.size() > fieldHierarchySize) {
+                                fieldHierarchy.pop();
+                            }
+                            while (restType.size() > restTypeSize) {
+                                restType.pop();
+                            }
+                            while (fieldNames.size() > fieldNamesSize) {
+                                fieldNames.pollLast();
+                            }
                         }
                     }
                     throw DiagnosticLog.error(DiagnosticErrorCode.INCOMPATIBLE_TYPE, type, json);


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/wso2/product-ballerina-integrator/issues/2560



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes a bug in the `parseAsType` API that prevented correct parsing of JSON responses with union type fields. When the parser attempted to convert valid JSON to a Ballerina type containing union types, it would fail with an error about missing fields, even when those fields were actually present in the JSON.

## Changes

**Root Cause Fix:**
The parser's internal traversal state was not being properly reset when attempting to parse each member of a union type. When one union member failed to match, leftover state from that attempt would corrupt subsequent attempts, causing valid JSON to be rejected.

**Implementation:**
Modified the JSON traversal logic to explicitly save and restore the parser's internal state (field hierarchy, type information, and field names) before attempting to match each union type member. If a member fails to parse, the saved state is restored before trying the next member. This ensures that failed attempts don't leave behind partial state that interferes with subsequent union member evaluations.

**Dependencies:**
- Updated native library from version 1.1.3 to 1.1.4
- Updated compiler plugin to snapshot version 1.1.4
- Updated os package dependency to version 1.10.1

## Outcome

The `parseAsType` API now correctly handles JSON responses with union-typed fields, resolving parsing failures that previously occurred with valid JSON inputs like OpenAI API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->